### PR TITLE
Update tests with rule names

### DIFF
--- a/tests/errors-distinct.tsv
+++ b/tests/errors-distinct.tsv
@@ -1,7 +1,8 @@
 table	cell	rule ID	rule	level	message	suggestion
-external_distinct	E2	field:8		ERROR	"'Degue virus' must meet one of: blank, under(external.Parent, ""material entity"")"
-external_distinct	D3	field:7		ERROR	'process' from external.Parent must exist in external.Label	
-exposure_distinct	E2	rule:7	"When the exposure process is ""occurrence of disease"" then the disease reported must be provided."	ERROR	"because 'occurrence of disease' is 'under(external.Parent, ""occurrence of disease"")', value must not be blank"	
-exposure_distinct	B3	rule:4	The exposure material ID must match the exposure material reported.	ERROR	because 'Dengue virus' is 'not(blank)', 'NCBITaxon:11103' must be 'NCBITaxon:12637'	NCBITaxon:12637
-external_distinct	A4	field:5		ERROR	'ONTIE:0003317' must be distinct with value(s) at: external:A16	
-external_distinct	A5	field:5		ERROR	'ONTIE:0003317' must be distinct with value(s) at: external:A15	
+external_distinct	E2	field:8	Material Basis	ERROR	"'Degue virus' must meet one of: blank, under(external.Parent, ""material entity"")"	
+external_distinct	D3	field:7	Parent	ERROR	'process' from external.Parent must exist in external.Label	
+external_distinct	A3	field:5	ID	ERROR	'IE_1' must be of datatype 'numeric'	
+external_distinct	A4	field:5	ID	ERROR	'ONTIE:0003317' must be distinct with value(s) at: external:A16	
+external_distinct	A5	field:5	ID	ERROR	'ONTIE:0003317' must be distinct with value(s) at: external:A15	
+exposure_distinct	E2	rule:7	Disease Reported	ERROR	"because 'occurrence of disease' is 'under(external.Parent, ""occurrence of disease"")', value must not be blank"	
+exposure_distinct	B3	rule:4	Exposure Material ID	ERROR	because 'Dengue virus' is 'not(blank)', 'NCBITaxon:11103' must be 'NCBITaxon:12637'	NCBITaxon:12637

--- a/tests/errors.tsv
+++ b/tests/errors.tsv
@@ -1,7 +1,8 @@
 table	cell	rule ID	rule	level	message	suggestion
-external	D11	field:7		ERROR	'process' from external.Parent must exist in external.Label	
-external	E7	field:8		ERROR	"'Degue virus' must meet one of: blank, under(external.Parent, ""material entity"")"	
-external	A15	field:5		ERROR	'ONTIE:0003317' must be distinct with value(s) at: external:A16	
-external	A16	field:5		ERROR	'ONTIE:0003317' must be distinct with value(s) at: external:A15	
-exposure	E5	rule:7		ERROR	"because 'occurrence of disease' is 'under(external.Parent, ""occurrence of disease"")', value must not be blank"	
-exposure	B6	rule:4		ERROR	because 'Dengue virus' is 'not(blank)', 'NCBITaxon:11103' must be 'NCBITaxon:12637'	NCBITaxon:12637
+external	D11	field:7	Parent	ERROR	'process' from external.Parent must exist in external.Label	
+external	E7	field:8	Material Basis	ERROR	"'Degue virus' must meet one of: blank, under(external.Parent, ""material entity"")"	
+external	A11	field:5	ID	ERROR	'IE_1' must be of datatype 'numeric'	
+external	A15	field:5	ID	ERROR	'ONTIE:0003317' must be distinct with value(s) at: external:A16	
+external	A16	field:5	ID	ERROR	'ONTIE:0003317' must be distinct with value(s) at: external:A15	
+exposure	E5	rule:7	Disease Reported	ERROR	"because 'occurrence of disease' is 'under(external.Parent, ""occurrence of disease"")', value must not be blank"	
+exposure	B6	rule:4	Exposure Material ID	ERROR	because 'Dengue virus' is 'not(blank)', 'NCBITaxon:11103' must be 'NCBITaxon:12637'	NCBITaxon:12637

--- a/tests/errors_distinct.tsv
+++ b/tests/errors_distinct.tsv
@@ -1,7 +1,0 @@
-table	cell	rule ID	rule	level	message	suggestion
-external_distinct	E2	field:8		ERROR	"'Degue virus' must meet one of: blank, under(external.Parent, ""material entity"")"	
-external_distinct	D3	field:7		ERROR	'process' from external.Parent must exist in external.Label	
-external_distinct	A4	field:5		ERROR	'ONTIE:0003317' must be distinct with value(s) at: external:A16	
-external_distinct	A5	field:5		ERROR	'ONTIE:0003317' must be distinct with value(s) at: external:A15	
-exposure_distinct	E2	rule:7		ERROR	"because 'occurrence of disease' is 'under(external.Parent, ""occurrence of disease"")', value must not be blank"	
-exposure_distinct	B3	rule:4		ERROR	because 'Dengue virus' is 'not(blank)', 'NCBITaxon:11103' must be 'NCBITaxon:12637'	NCBITaxon:12637


### PR DESCRIPTION
See https://github.com/ontodev/valve.py/pull/49

Adds the failing column as the rule name.

Also removes a duplicate `errors_distinct.tsv` file from tests.